### PR TITLE
Allow quoted arguments to be redirected to php oil

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f "./oil" ]; then
-        php oil $@
+        php oil "$@"
 else
 
         if [ "$1" == "create" ]; then


### PR DESCRIPTION
the php oil shortcut does not allow quotes in the command, and breaks argument strings with spaces like:

```
$ oil refine test -argument="some argument with spaces"
```

Now its redirected to:

```
$ php oil refine test -argument=some argument with spaces
```

The quotes around $@ fix this and the redirected command will be:

```
$ php oil refine test -argument="some argument with spaces"
```
