### PR TITLE
Allow to customize installation PREFIX.

### DIFF
--- a/oil
+++ b/oil
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-PREFIX="/usr/bin/"
+# Export PREFIX with a custom directory or use default one.
+if [ -z "$PREFIX" ]; then
+	PREFIX="/usr/bin/"
+fi
 
 install_oil() {
 
@@ -17,10 +20,9 @@ install_oil() {
 # Handle execution
 #
 main() {
-
-  # Start installation
-  install_oil
-  exit 0
+	# Start installation
+	install_oil
+	exit 0
 }
 
 main


### PR DESCRIPTION
This way users can choose where to install `oil` instead of forcing everyone to use `/usr/bin/`.

I also fixed a problem with the indentation in `main` using spaces instead of tabs, which I think is what you folks are using.

If you are OK, I would like to submit another enhancement, basically, if the user already has write permissions in `$PREFIX` then using sudo wouldn't be needed, and tidying up the `if else fi` to reduce repitition.