### PR TITLE
Update installer

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -5,27 +5,26 @@ if [ -f "./oil" ]; then
         php oil "$@"
 else
 
-		# check for bash commandline options
+        # check for bash commandline options
         if [ "$1" == "create" ]; then
 
-				# make sure git is installed
+                # make sure git is installed
                 if [ ! `which git` ]; then
                     echo "For this installer to work you'll need to install Git."
                     echo '        http://git-scm.com/'
                 fi
 
-				# clone the repository, and make sure the latest master is active
-                git clone --recursive git://github.com/fuel/fuel.git "./$2"
+                # clone the repository, and make sure the latest master is active
+                git clone git://github.com/fuel/fuel.git "./$2"
                 cd ./$2
                 branch=`git branch -a | grep -v "remote" | grep "master" | tail -1`
                 branch=${branch#* }
                 git checkout $branch
-                git submodule foreach git checkout $branch
                 
                 # run composer
                 php composer.phar self-update
-                php composer.phar update
-                
+                php composer.phar update --prefer-dist
+
                 # fix potential rights issues
                 cd ..
                 php "./$2/oil" refine install


### PR DESCRIPTION
I've update `oil` command. This does not use git submodule no longer.

By the way, `oil create` clones `fuel/fuel` and does not remove its `.git` folder.
I did not change the behaviour.

In contrast, `composer create-project fuel/fuel:dev-1.7/master --prefer-dist` removes `.git` automatically. (Because we add `--prefer-dist`.)

So the results of `oil create` and `composer create-project` differ. If you want the exact same results, you have to remove `.git` folder of `fuel/fuel` in `oil create` command.

Of course `.git` folders in dependencies do not exist whichever you select installation method.
